### PR TITLE
Fix base URL env variable handling

### DIFF
--- a/src/Update-LidarrAlbumMonitoring.ps1
+++ b/src/Update-LidarrAlbumMonitoring.ps1
@@ -1,5 +1,6 @@
 # Get configuration from environment variables
-$lidarrBaseUrl = $env:LIDARR_BASE_URL.TrimEnd('/')
+$lidarrBaseUrl = $env:LIDARR_BASE_URL
+if ($lidarrBaseUrl) { $lidarrBaseUrl = $lidarrBaseUrl.TrimEnd('/') }
 $apiKey = $env:LIDARR_API_KEY
 # Get days to look back with default of 60 if not specified
 $daysToLookBack = if ($env:DAYS_TO_LOOK_BACK) { [int]$env:DAYS_TO_LOOK_BACK } else { 60 }


### PR DESCRIPTION
## Summary
- handle missing `LIDARR_BASE_URL` env var gracefully

## Testing
- `pwsh -File src/Update-LidarrAlbumMonitoring.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6de44d74832cb83c796345033c54