### PR TITLE
Fix OOM by using calendar endpoint instead of fetching all albums

### DIFF
--- a/src/Update-LidarrAlbumMonitoring.ps1
+++ b/src/Update-LidarrAlbumMonitoring.ps1
@@ -16,25 +16,26 @@ if (-not $lidarrBaseUrl -or -not $apiKey) {
 Write-Output "Connecting to Lidarr API at $lidarrApiUrl"
 Write-Output "Looking for albums released in the last $daysToLookBack days"
 
-$albumsUrl = "$lidarrApiUrl/album?apikey=$apiKey"
-$artistsUrl = "$lidarrApiUrl/artist?apikey=$apiKey"
+# Use the calendar endpoint so Lidarr filters by release date server-side.
+# Fetching /album unfiltered returns the entire library and OOMs on large
+# libraries during JSON deserialization. includeArtist embeds the artist on
+# each album, so no separate /artist fetch is needed either.
+$startDate = (Get-Date).AddDays(-$daysToLookBack).ToString('yyyy-MM-dd')
+$endDate = (Get-Date).AddDays(1).ToString('yyyy-MM-dd')   # +1 to catch today across timezones
+$calendarUrl = "$lidarrApiUrl/calendar?apikey=$apiKey&start=$startDate&end=$endDate&unmonitored=true&includeArtist=true"
 
-$artistsResponse = Invoke-RestMethod -Uri $artistsUrl -Method Get
-$albumResponse = Invoke-RestMethod -Uri $albumsUrl -Method Get
-$nextAlbum = $albumResponse | Where-Object { 
-    $_.ReleaseDate -and (Get-Date $_.ReleaseDate) -gt (Get-Date).AddDays(-$daysToLookBack)
-}
+$recentAlbums = Invoke-RestMethod -Uri $calendarUrl -Method Get
 
 $updateAlbumUrl = "$lidarrApiUrl/album/monitor?apikey=$apiKey"
 
-foreach ($album in $nextAlbum) {
-    $albumPs = [PSCustomObject]@{
-        albumIds  = @($album.id)
-        monitored = $true
-    }
-    $albumJson = $albumPs | ConvertTo-Json -Depth 2
-    $artistMatch = $artistsResponse.Where({ $_.id -eq $album.artist.id }, 'First')
-    if (($artistMatch.monitorNewItems -ne "none") -and ($artistMatch.monitored -eq $true)) {
+foreach ($album in $recentAlbums) {
+    if ($album.monitored) { continue }
+    if (($album.artist.monitorNewItems -ne "none") -and ($album.artist.monitored -eq $true)) {
+        $albumPs = [PSCustomObject]@{
+            albumIds  = @($album.id)
+            monitored = $true
+        }
+        $albumJson = $albumPs | ConvertTo-Json -Depth 2
         Invoke-RestMethod -Uri $updateAlbumUrl -Method Put -Body $albumJson -ContentType "application/json"
     }
 }


### PR DESCRIPTION
## Problem

Fixes #31.

The daily run was OOM-killed every morning (5-7GB RSS without a container limit; `System.OutOfMemoryException` in ~24s with a 2GB limit). Root cause: the unfiltered `GET /api/v1/album` call at line 23 returns the **entire album library**, and `Invoke-RestMethod`'s JSON->PSObject materialization (roughly 10-20x raw JSON size) blows past available memory before the client-side date filter ever runs. The `/album` endpoint has no release-date filter parameter, so there was nothing to fix on that call -- it's the wrong endpoint for this job.

## Fix

Use the endpoint purpose-built for "what released in date range X":

```
GET /api/v1/calendar?start=<lookback>&end=<tomorrow>&unmonitored=true&includeArtist=true
```

- **Server-side date filtering** -- the response is just the albums in the lookback window, bytes instead of gigabytes
- **`unmonitored=true`** -- includes the unmonitored albums this script exists to flip
- **`includeArtist=true`** -- embeds the artist on each album, eliminating the separate unbounded `/artist` fetch *and* the client-side artist matching loop
- **Bonus:** albums already monitored are now skipped instead of redundantly re-PUT

All four calendar params verified against the Lidarr OpenAPI spec. Selection logic is equivalent to the old `ReleaseDate` filter, just done server-side (`end` is +1 day to catch same-day releases across timezones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)